### PR TITLE
fix for some strange auto generated makefile that use -C .

### DIFF
--- a/internal/parser.go
+++ b/internal/parser.go
@@ -197,7 +197,9 @@ func Parse(buildLog []string) {
 			if group != nil && len(group) >= 2 {
 				enterDir := group[1]
 				dirStack = append([]string{ConvertPath(enterDir)}, dirStack...)
-				workingDir = dirStack[0]
+				if dirStack[0] != "." {
+					workingDir = dirStack[0]
+				}
 				log.Infof("make cmd change workingDir: %s", workingDir)
 			}
 		}


### PR DESCRIPTION
hello

thanks to you I can use my makefile generator but it use some strange rule

`@${MAKE} --no-print-directory -C . -f engine.make config=$(engine_config)`
and so the directory is now . and not my real folder leading to some include error since compile_commands is not loaded correctly 

I've try to make the fix clean but as I said I don't really know GO and good practice in so feel free to make remarks if need  