### PR TITLE
README: the "needs a clean build" contrast no longer applies to Bear

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Tool for generating [Clang's JSON Compilation Database][compdb] file for GNU
 It's aimed mainly at non-cmake (cmake already generates compilation database)
 large codebases. Inspired by projects like [YCM-Generator][ycm-gen] and [Bear][bear],
 but faster (mainly with large projects), since in most cases it **doesn't need a clean
-build** (as the mentioned tools do) to generate the compilation database file, to
+build** (as YCM-Generator does) to generate the compilation database file, to
 achieve this it uses the make options such as `--dry-run/-n` and `--keep-going/-k`
 to extract the compile commands. Also, it's more **cross-compiling friendly** than
 YCM-generator's fake-toolchanin approach.


### PR DESCRIPTION
Bear 4.2.0 (released 2026-08-01) added a `bear parse-sh` subcommand that reads shell command text such as `make -n` output and writes `compile_commands.json` without running a build, so the parenthetical sweeps in a tool it no longer describes.

YCM-Generator still runs the build behind a fake toolchain, so the contrast holds for it. I narrowed the comparison rather than removing it, which leaves the rest of the sentence, including the speed claim, untouched.

Disclosure: I maintain Bear. Happy to drop this if you would rather word it differently.

There is also a typo in the next sentence ("fake-toolchanin") that I left alone to keep this to one change; say the word and I will fold it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)