### PR TITLE
fix: track recursive Make directories

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,9 @@ jobs:
         with:
           go-version: stable
 
+      - name: Test Make proxy paths
+        run: go test ./internal -run '^TestMakeProxy' -count=1
+
       - name: Build and smoke test
         run: |
           test "$(go env GOOS)/$(go env GOARCH)" = "windows/amd64"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - `compiledb make --cmd/-c COMMAND` selects the GNU Make-compatible executable for both real and discovery invocations. Before the first `--`, the subcommand consumes this option and `--help/-h` with the original Click short-cluster semantics; the first `--` is a wrapper delimiter and is not forwarded, while all following arguments are. Other Make arguments preserve their order and value outside recognized short-option clusters. Top-level `--command-style/-c` is parsed before `make` and remains a separate option.
 - Real Make failure takes precedence over dry-run failure. If the real build succeeds but the dry run fails, the dry-run status is returned. Under `--no-build`, dry-run failure is returned directly. A failed discovery never creates or updates the database, even when it produced partial stdout.
 - Discovery parsing consumes stdout only. Discovery stderr is forwarded to stderr as user-visible diagnostics and must never be parsed as compiler commands or written to JSON stdout.
+- Discovery-only recursive `$(MAKE)` calls use an internal proxy that removes child `--no-print-directory`, requests `--print-directory`, and delegates to the same resolved Make executable. The real build is never proxied. Explicit `MAKE` selection and `-e/--environment-overrides` retain user semantics. Hard-coded Make paths, wrappers that replace themselves with a hard-coded Make, Makefile `override MAKEFLAGS` that disables markers, and direct build-log parsing remain outside its scope.
 - Backtick expressions in build-log lines are executed by an embedded POSIX shell interpreter before command extraction. Do not feed untrusted logs to the parser. Preserve or explicitly test this behavior when changing parser flow.
 - Shell builtins in backtick expressions do not require an external shell executable. Programs explicitly invoked by the expression must still be available through `PATH`; execution failure emits a recoverable Error, skips only that command, and keeps status 0.
 - On Windows, the supported wrapper/parser combination is a GNU Make-compatible executable with POSIX/MSYS-style recipe output. `--cmd/-c` can select `gmake` or `mingw32-make`; native `cmd.exe` recipe grammar and `nmake` are out of scope.
@@ -44,7 +45,7 @@
 - Focus a test with `go test ./internal -run '^TestName$'` or `go test ./cmd/compiledb -run '^TestName$'`.
 - Build without leaving a repository artifact using `go build -o /tmp/compiledb-go ./cmd/compiledb`. The root `compiledb` binary is ignored, but `/tmp` is preferred for manual verification.
 - Do not treat `just` as a normal build check. `.justfile` requires Nushell, and its default `build` recipe runs the CLI against `tests/build.log`, generating `compile_commands.json` rather than only compiling the binary.
-- The release workflow gates Linux amd64 on gofmt, vet, tests, and race tests. Linux amd64/arm64, Windows amd64, and macOS arm64 artifacts are built natively and must run `--help` before publication. Local verification remains required.
+- The release workflow gates Linux amd64 on gofmt, vet, tests, and race tests. Windows amd64 also runs the native Make proxy path regression. Linux amd64/arm64, Windows amd64, and macOS arm64 artifacts are built natively and must run `--help` before publication. Local verification remains required.
 
 ## Test And Artifact Gotchas
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,13 @@ $ compiledb -n make
 Only successful discovery output updates the database. Make output and diagnostics go to stderr
 when `--output -` is used, keeping stdout valid JSON.
 
+During discovery, recursive `$(MAKE)` commands use the selected GNU Make executable through an
+internal proxy that removes a recipe's `--no-print-directory` and requests directory markers. This
+keeps sibling and nested `-C` directories distinct without changing the real build. Explicit `MAKE`
+selection and Make's `-e/--environment-overrides` semantics are preserved. Hard-coded Make paths,
+wrappers that replace themselves with a hard-coded Make, Makefiles that use `override MAKEFLAGS` to
+disable markers, and saved build logs remain outside this interception.
+
 ### Parse A Build Log
 
 Parse a saved build log, read stdin, or pipe Make output directly:

--- a/internal/init_unix_test.go
+++ b/internal/init_unix_test.go
@@ -5,6 +5,7 @@ package internal
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -73,6 +74,155 @@ func TestExpandCompilerResponseFilesAcceptsDoubleSlashAbsolutePath(t *testing.T)
 	want := []string{"gcc", "-c", "main.c"}
 	if !slices.Equal(result, want) {
 		t.Fatalf("unexpected response arguments: want %#v, got %#v", want, result)
+	}
+}
+
+func TestShellSafeMakeProxyPathAcceptsNonUTF8Path(t *testing.T) {
+	proxyPath := string([]byte{'/', 't', 'm', 'p', '/', 0xff, '/', 'm', 'a', 'k', 'e'})
+	if !shellSafeMakeProxyPath(proxyPath) {
+		t.Fatalf("shell-safe proxy path was rejected: %q", proxyPath)
+	}
+}
+
+func TestInstallMakeProxyExecutableResolvesRelativeSymlink(t *testing.T) {
+	sourceDir := t.TempDir()
+	target := filepath.Join(sourceDir, "compiledb-real")
+	if err := os.WriteFile(target, []byte("proxy executable"), 0o700); err != nil {
+		t.Fatalf("write proxy executable failed: %v", err)
+	}
+	link := filepath.Join(sourceDir, "compiledb")
+	if err := os.Symlink(filepath.Base(target), link); err != nil {
+		t.Skipf("create executable symlink failed: %v", err)
+	}
+	oldWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory failed: %v", err)
+	}
+	if err := os.Chdir(sourceDir); err != nil {
+		t.Fatalf("change working directory failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWorkingDir) })
+	proxyPath := filepath.Join(t.TempDir(), "make")
+	if err := installMakeProxyExecutable(filepath.Base(link), proxyPath); err != nil {
+		t.Fatalf("install executable proxy failed: %v", err)
+	}
+	if _, err := filepath.EvalSymlinks(proxyPath); err != nil {
+		t.Fatalf("resolve executable proxy failed: %v", err)
+	}
+	info, err := os.Lstat(proxyPath)
+	if err != nil {
+		t.Fatalf("stat executable proxy failed: %v", err)
+	}
+	contents, err := os.ReadFile(proxyPath)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 || string(contents) != "proxy executable" {
+		t.Fatalf("resolved symlink was not preferred for the proxy: mode=%v contents=%q error=%v", info.Mode(), contents, err)
+	}
+}
+
+func TestCreateDiscoveryMakeProxyRejectsNonExecutableSource(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "compiledb")
+	if err := os.WriteFile(executable, []byte("not executable"), 0o600); err != nil {
+		t.Fatalf("write non-executable source failed: %v", err)
+	}
+	parent := t.TempDir()
+	proxyPath, cleanup, err := createDiscoveryMakeProxyIn(parent, executable, "/tools/gmake")
+	if err == nil {
+		cleanup()
+		t.Fatalf("non-executable proxy was accepted: %q", proxyPath)
+	}
+	entries, readErr := os.ReadDir(parent)
+	if readErr != nil || len(entries) != 0 {
+		t.Fatalf("failed proxy was not cleaned up: entries=%v error=%v", entries, readErr)
+	}
+}
+
+func TestCreateDiscoveryMakeProxyFallsBackAfterCandidateFailure(t *testing.T) {
+	unsafeParent := filepath.Join(t.TempDir(), "unsafe parent")
+	safeParent := t.TempDir()
+	if err := os.Mkdir(unsafeParent, 0o755); err != nil {
+		t.Fatalf("create unsafe parent failed: %v", err)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("get executable failed: %v", err)
+	}
+	proxyPath, cleanup, err := createDiscoveryMakeProxyFromParents(executable, "/tools/gmake", []string{unsafeParent, safeParent})
+	if err != nil {
+		t.Fatalf("fall back to safe proxy parent failed: %v", err)
+	}
+	defer cleanup()
+	if filepath.Dir(filepath.Dir(proxyPath)) != safeParent {
+		t.Fatalf("unexpected proxy fallback path: %q", proxyPath)
+	}
+	entries, err := os.ReadDir(unsafeParent)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("failed proxy candidate was not cleaned up: entries=%v error=%v", entries, err)
+	}
+}
+
+func TestMakeProxyDelegatesToSelectedExecutable(t *testing.T) {
+	selectedMake := filepath.Join(t.TempDir(), "selected-make")
+	outputFile := filepath.Join(t.TempDir(), "invocation")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$0\" \"$@\" > \"$COMPILEDB_TEST_MAKE_PROXY_OUTPUT\"\n"
+	if err := os.WriteFile(selectedMake, []byte(script), 0o700); err != nil {
+		t.Fatalf("write selected Make executable failed: %v", err)
+	}
+	proxyPath, cleanup, err := createDiscoveryMakeProxy(selectedMake)
+	if err != nil {
+		t.Fatalf("create Make proxy failed: %v", err)
+	}
+	defer cleanup()
+
+	command := exec.Command(proxyPath, "--no-print-directory", "goal")
+	command.Env = append(os.Environ(), "COMPILEDB_TEST_MAKE_PROXY_OUTPUT="+outputFile)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("run Make proxy failed: %v: %s", err, output)
+	}
+	contents, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read delegated invocation failed: %v", err)
+	}
+	arguments := strings.Split(strings.TrimSpace(string(contents)), "\n")
+	if len(arguments) != 3 || arguments[0] != selectedMake || arguments[1] != "--print-directory" || arguments[2] != "goal" {
+		t.Fatalf("proxy did not delegate to the selected Make: %#v", arguments)
+	}
+}
+
+func TestMakeProxyCheckArgumentIsDelegatedAfterCreation(t *testing.T) {
+	selectedMake := filepath.Join(t.TempDir(), "selected-make")
+	outputFile := filepath.Join(t.TempDir(), "invocation")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$COMPILEDB_TEST_MAKE_PROXY_OUTPUT\"\n"
+	if err := os.WriteFile(selectedMake, []byte(script), 0o700); err != nil {
+		t.Fatalf("write selected Make executable failed: %v", err)
+	}
+	proxyPath, cleanup, err := createDiscoveryMakeProxy(selectedMake)
+	if err != nil {
+		t.Fatalf("create Make proxy failed: %v", err)
+	}
+	defer cleanup()
+
+	command := exec.Command(proxyPath, makeProxyCheckArgument)
+	command.Env = append(os.Environ(), "COMPILEDB_TEST_MAKE_PROXY_OUTPUT="+outputFile)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("run Make proxy failed: %v: %s", err, output)
+	}
+	contents, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read delegated invocation failed: %v", err)
+	}
+	want := "--print-directory\n" + makeProxyCheckArgument + "\n"
+	if string(contents) != want {
+		t.Fatalf("proxy check argument was not delegated: want %q, got %q", want, contents)
+	}
+}
+
+func TestReadMakeProxyMetadataRejectsFIFO(t *testing.T) {
+	metadata := filepath.Join(t.TempDir(), makeProxyMetadataName)
+	if err := syscall.Mkfifo(metadata, 0o600); err != nil {
+		t.Fatalf("create metadata FIFO failed: %v", err)
+	}
+	if value, ok := readMakeProxyMetadata(metadata); ok {
+		t.Fatalf("metadata FIFO was accepted: %q", value)
 	}
 }
 

--- a/internal/make_proxy.go
+++ b/internal/make_proxy.go
@@ -1,0 +1,310 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const (
+	makeProxyDirectoryPrefix = ".compiledb-make-proxy-"
+	makeProxyMetadataName    = ".real-make"
+	makeProxyCheckName       = ".check"
+	makeProxyCheckArgument   = "--compiledb-internal-make-proxy-check"
+)
+
+func init() {
+	proxyPath, realMake, ok := makeProxyInvocation()
+	if !ok {
+		return
+	}
+	if len(os.Args) == 2 && os.Args[1] == makeProxyCheckArgument && makeProxyCheckInvocation(proxyPath) {
+		os.Exit(0)
+	}
+	err := executeMakeProxy(realMake, proxyPath, recursiveMakeArguments(os.Args[1:]))
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			os.Exit(commandExitCode(exitErr))
+		}
+		_, _ = fmt.Fprintf(os.Stderr, "compiledb make proxy: %v\n", err)
+		if errors.Is(err, os.ErrNotExist) {
+			os.Exit(127)
+		}
+		os.Exit(commandExitCode(err))
+	}
+	os.Exit(0)
+}
+
+func recursiveMakeArguments(arguments []string) []string {
+	result := make([]string, 1, len(arguments)+1)
+	result[0] = "--print-directory"
+	options := true
+	for index := 0; index < len(arguments); index++ {
+		argument := arguments[index]
+		if options && argument == "--" {
+			options = false
+			result = append(result, argument)
+			continue
+		}
+		if options && !strings.Contains(argument, "=") {
+			if name, ok := canonicalMakeLongOption(argument); ok && name == "no-print-directory" {
+				continue
+			}
+		}
+		result = append(result, argument)
+		if options && makeOptionTakesFollowingArgument(argument, arguments[index+1:]) && index+1 < len(arguments) {
+			index++
+			result = append(result, arguments[index])
+		}
+	}
+	return result
+}
+
+func configureDiscoveryMakeProxy(command *exec.Cmd) (func(), error) {
+	if command.Err != nil {
+		return func() {}, nil
+	}
+	workingDir := command.Dir
+	if workingDir == "" {
+		var err error
+		workingDir, err = os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+	}
+	proxyPath, cleanup, err := createDiscoveryMakeProxy(command.Path, workingDir)
+	if err != nil {
+		return nil, err
+	}
+	command.Args[0] = proxyPath
+	return cleanup, nil
+}
+
+func createDiscoveryMakeProxy(realMake string, fallbackParents ...string) (string, func(), error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", nil, err
+	}
+	parents := makeProxyTempDirectories(fallbackParents...)
+	if len(parents) == 0 {
+		return "", nil, fmt.Errorf("temporary directory %q is not absolute", os.TempDir())
+	}
+	return createDiscoveryMakeProxyFromParents(executable, realMake, parents)
+}
+
+func createDiscoveryMakeProxyFromParents(executable, realMake string, parents []string) (string, func(), error) {
+	var failures []error
+	for _, parent := range parents {
+		proxyPath, cleanup, err := createDiscoveryMakeProxyIn(parent, executable, realMake)
+		if err == nil {
+			return proxyPath, cleanup, nil
+		}
+		failures = append(failures, err)
+	}
+	return "", nil, errors.Join(failures...)
+}
+
+func createDiscoveryMakeProxyIn(parent, executable, realMake string) (string, func(), error) {
+	directory, err := os.MkdirTemp(parent, makeProxyDirectoryPrefix)
+	if err != nil {
+		return "", nil, err
+	}
+	originalDirectory := directory
+	directory, err = filepath.Abs(directory)
+	if err != nil {
+		_ = os.RemoveAll(originalDirectory)
+		return "", nil, err
+	}
+	cleanup := func() { _ = os.RemoveAll(directory) }
+	metadataPath := filepath.Join(directory, makeProxyMetadataName)
+	if err := os.WriteFile(metadataPath, []byte(realMake), 0o600); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	proxyName := "make"
+	if runtime.GOOS == "windows" {
+		proxyName += ".exe"
+	}
+	proxyPath := filepath.Join(directory, proxyName)
+	if strings.ContainsAny(proxyPath, "\r\n") {
+		cleanup()
+		return "", nil, errors.New("Make proxy path cannot contain newlines")
+	}
+	if err := installMakeProxyExecutable(executable, proxyPath); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	checkPath := filepath.Join(directory, makeProxyCheckName)
+	if err := os.WriteFile(checkPath, nil, 0o600); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	if err := exec.Command(proxyPath, makeProxyCheckArgument).Run(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("verify Make proxy executable: %w", err)
+	}
+	if err := os.Remove(checkPath); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	commandPath, err := makeProxyCommandPath(proxyPath)
+	if err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return commandPath, cleanup, nil
+}
+
+func makeProxyInvocation() (string, string, bool) {
+	if len(os.Args) == 0 {
+		return "", "", false
+	}
+	proxyPath, err := filepath.Abs(os.Args[0])
+	if err != nil || executableBase(proxyPath) != "make" {
+		return "", "", false
+	}
+	identityPath, err := makeProxyIdentityPath(proxyPath)
+	if err != nil || !strings.HasPrefix(filepath.Base(filepath.Dir(identityPath)), makeProxyDirectoryPrefix) {
+		return "", "", false
+	}
+	metadata, ok := readMakeProxyMetadata(filepath.Join(filepath.Dir(identityPath), makeProxyMetadataName))
+	if !ok {
+		return "", "", false
+	}
+	return os.Args[0], metadata, true
+}
+
+func makeProxyCheckInvocation(proxyPath string) bool {
+	identityPath, err := makeProxyIdentityPath(proxyPath)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(filepath.Dir(identityPath), makeProxyCheckName))
+	return err == nil && info.Mode().IsRegular()
+}
+
+func shellSafeMakeProxyPath(filename string) bool {
+	if filename == "" {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		filename = strings.ReplaceAll(filename, `\`, "/")
+	}
+	if !filepath.IsAbs(filename) {
+		return false
+	}
+	const safe = "_@%+=:,./-~"
+	for index := 0; index < len(filename); index++ {
+		character := filename[index]
+		if character > 0x7f ||
+			(character >= 'a' && character <= 'z') ||
+			(character >= 'A' && character <= 'Z') ||
+			(character >= '0' && character <= '9') ||
+			strings.IndexByte(safe, character) >= 0 {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func makeProxyTempDirectories(fallbackParents ...string) []string {
+	tempDir := os.TempDir()
+	candidates := makeProxyTempDirectoryCandidates(tempDir, fallbackParents)
+	directories := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, cap(directories))
+	appendDirectory := func(directory string) {
+		if !filepath.IsAbs(directory) {
+			return
+		}
+		directory = filepath.Clean(directory)
+		key := directory
+		if runtime.GOOS == "windows" {
+			key = strings.ToLower(key)
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		directories = append(directories, directory)
+	}
+	for _, directory := range candidates {
+		appendDirectory(directory)
+	}
+	return directories
+}
+
+func makeProxyCommandPathOther(proxyPath string) (string, error) {
+	if shellSafeMakeProxyPath(proxyPath) {
+		return proxyPath, nil
+	}
+	return "", fmt.Errorf("Make proxy path %q is not safe for recursive recipes", proxyPath)
+}
+
+func readMakeProxyMetadata(filename string) (string, bool) {
+	metadataFile, err := openMakeProxyMetadata(filename)
+	if err != nil {
+		return "", false
+	}
+	info, statErr := metadataFile.Stat()
+	if statErr != nil || !info.Mode().IsRegular() {
+		_ = metadataFile.Close()
+		return "", false
+	}
+	metadata, readErr := io.ReadAll(io.LimitReader(metadataFile, 64*1024+1))
+	closeErr := metadataFile.Close()
+	if readErr != nil || closeErr != nil || len(metadata) == 0 || len(metadata) > 64*1024 ||
+		strings.IndexByte(string(metadata), 0) >= 0 {
+		return "", false
+	}
+	return string(metadata), true
+}
+
+func makeProxyCommand(realMake, proxyName string, arguments ...string) *exec.Cmd {
+	command := exec.Command(realMake, arguments...)
+	command.Args[0] = proxyName
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Env = os.Environ()
+	return command
+}
+
+func installMakeProxyExecutable(executable, proxyPath string) error {
+	absoluteExecutable, err := filepath.Abs(executable)
+	if err != nil {
+		return err
+	}
+	resolvedExecutable, err := filepath.EvalSymlinks(absoluteExecutable)
+	if err != nil {
+		return err
+	}
+	executable = resolvedExecutable
+	if err := os.Symlink(executable, proxyPath); err == nil {
+		return nil
+	}
+	if err := os.Link(executable, proxyPath); err == nil {
+		return nil
+	}
+	source, err := os.Open(executable)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	destination, err := os.OpenFile(proxyPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o700)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(destination, source)
+	closeErr := destination.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}

--- a/internal/make_proxy_metadata_other.go
+++ b/internal/make_proxy_metadata_other.go
@@ -1,0 +1,9 @@
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris
+
+package internal
+
+import "os"
+
+func openMakeProxyMetadata(filename string) (*os.File, error) {
+	return os.Open(filename)
+}

--- a/internal/make_proxy_metadata_unix.go
+++ b/internal/make_proxy_metadata_unix.go
@@ -1,0 +1,18 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package internal
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openMakeProxyMetadata(filename string) (*os.File, error) {
+	fd, err := unix.Open(filename, unix.O_RDONLY|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	unix.CloseOnExec(fd)
+	return os.NewFile(uintptr(fd), filename), nil
+}

--- a/internal/make_proxy_other.go
+++ b/internal/make_proxy_other.go
@@ -1,0 +1,7 @@
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris
+
+package internal
+
+func executeMakeProxy(realMake, proxyName string, arguments []string) error {
+	return makeProxyCommand(realMake, proxyName, arguments...).Run()
+}

--- a/internal/make_proxy_path_other.go
+++ b/internal/make_proxy_path_other.go
@@ -1,0 +1,15 @@
+//go:build !aix && !android && !darwin && !dragonfly && !freebsd && !illumos && !linux && !netbsd && !openbsd && !solaris && !windows
+
+package internal
+
+func makeProxyTempDirectoryCandidates(tempDir string, fallbackParents []string) []string {
+	return append([]string{tempDir}, fallbackParents...)
+}
+
+func makeProxyCommandPath(proxyPath string) (string, error) {
+	return makeProxyCommandPathOther(proxyPath)
+}
+
+func makeProxyIdentityPath(proxyPath string) (string, error) {
+	return proxyPath, nil
+}

--- a/internal/make_proxy_path_unix.go
+++ b/internal/make_proxy_path_unix.go
@@ -1,0 +1,16 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package internal
+
+func makeProxyTempDirectoryCandidates(tempDir string, fallbackParents []string) []string {
+	directories := append([]string{tempDir}, fallbackParents...)
+	return append(directories, "/tmp")
+}
+
+func makeProxyCommandPath(proxyPath string) (string, error) {
+	return makeProxyCommandPathOther(proxyPath)
+}
+
+func makeProxyIdentityPath(proxyPath string) (string, error) {
+	return proxyPath, nil
+}

--- a/internal/make_proxy_path_windows.go
+++ b/internal/make_proxy_path_windows.go
@@ -1,0 +1,65 @@
+package internal
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func makeProxyTempDirectoryCandidates(tempDir string, fallbackParents []string) []string {
+	directories := append([]string{tempDir}, fallbackParents...)
+	if windowsDir, err := windows.GetWindowsDirectory(); err == nil {
+		directories = append(directories, filepath.Join(windowsDir, "Temp"))
+	}
+	for _, directory := range append([]string(nil), directories...) {
+		volume := filepath.VolumeName(directory)
+		if volume != "" {
+			directories = append(directories, volume+string(filepath.Separator))
+		}
+	}
+	return directories
+}
+
+func makeProxyCommandPath(proxyPath string) (string, error) {
+	commandPath := strings.ReplaceAll(proxyPath, `\`, "/")
+	if shellSafeMakeProxyPath(commandPath) {
+		return commandPath, nil
+	}
+	longPath, err := windows.UTF16PtrFromString(proxyPath)
+	if err != nil {
+		return "", err
+	}
+	size, err := windows.GetShortPathName(longPath, nil, 0)
+	if err != nil {
+		return "", err
+	}
+	shortPath := make([]uint16, size)
+	length, err := windows.GetShortPathName(longPath, &shortPath[0], uint32(len(shortPath)))
+	if err != nil {
+		return "", err
+	}
+	commandPath = strings.ReplaceAll(windows.UTF16ToString(shortPath[:length]), `\`, "/")
+	if !shellSafeMakeProxyPath(commandPath) {
+		return "", fmt.Errorf("Make proxy path %q has no shell-safe short form", proxyPath)
+	}
+	return commandPath, nil
+}
+
+func makeProxyIdentityPath(proxyPath string) (string, error) {
+	longPath, err := windows.UTF16PtrFromString(proxyPath)
+	if err != nil {
+		return "", err
+	}
+	size, err := windows.GetLongPathName(longPath, nil, 0)
+	if err != nil {
+		return "", err
+	}
+	identityPath := make([]uint16, size)
+	length, err := windows.GetLongPathName(longPath, &identityPath[0], uint32(len(identityPath)))
+	if err != nil {
+		return "", err
+	}
+	return windows.UTF16ToString(identityPath[:length]), nil
+}

--- a/internal/make_proxy_unix.go
+++ b/internal/make_proxy_unix.go
@@ -1,0 +1,12 @@
+//go:build aix || android || darwin || dragonfly || freebsd || illumos || linux || netbsd || openbsd || solaris
+
+package internal
+
+import (
+	"os"
+	"syscall"
+)
+
+func executeMakeProxy(realMake, proxyName string, arguments []string) error {
+	return syscall.Exec(realMake, append([]string{proxyName}, arguments...), os.Environ())
+}

--- a/internal/make_proxy_windows_test.go
+++ b/internal/make_proxy_windows_test.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestMakeProxyShortPathRetainsLongIdentity(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "proxy path")
+	if err := os.Mkdir(parent, 0o755); err != nil {
+		t.Fatalf("create proxy parent failed: %v", err)
+	}
+	directory, err := os.MkdirTemp(parent, makeProxyDirectoryPrefix)
+	if err != nil {
+		t.Fatalf("create proxy directory failed: %v", err)
+	}
+	proxyPath := filepath.Join(directory, "make.exe")
+	if err := os.WriteFile(proxyPath, []byte("proxy"), 0o700); err != nil {
+		t.Fatalf("write proxy executable failed: %v", err)
+	}
+	const realMake = `C:\tools\gmake.exe`
+	if err := os.WriteFile(filepath.Join(directory, makeProxyMetadataName), []byte(realMake), 0o600); err != nil {
+		t.Fatalf("write proxy metadata failed: %v", err)
+	}
+
+	commandPath, err := makeProxyCommandPath(proxyPath)
+	if err != nil {
+		t.Skipf("short paths are unavailable on this volume: %v", err)
+	}
+	if !shellSafeMakeProxyPath(commandPath) || strings.ContainsAny(commandPath, ` \`+"\t\r\n") {
+		t.Fatalf("proxy command path is not shell-safe: %q", commandPath)
+	}
+	oldArg0 := os.Args[0]
+	os.Args[0] = commandPath
+	t.Cleanup(func() { os.Args[0] = oldArg0 })
+	invocationPath, selectedMake, ok := makeProxyInvocation()
+	if !ok || invocationPath != commandPath || selectedMake != realMake {
+		t.Fatalf("short proxy path lost long identity: path=%q make=%q ok=%v", invocationPath, selectedMake, ok)
+	}
+}
+
+func TestMakeProxyTempDirectoriesIncludeShellSafeFallbacks(t *testing.T) {
+	buildDir := `C:\work\build`
+	directories := makeProxyTempDirectories(buildDir)
+	windowsDir, err := windows.GetWindowsDirectory()
+	if err != nil {
+		t.Fatalf("get Windows directory failed: %v", err)
+	}
+	for _, want := range []string{buildDir, filepath.Join(windowsDir, "Temp"), `C:\`} {
+		found := false
+		for _, directory := range directories {
+			if strings.EqualFold(directory, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("missing Windows proxy fallback %q: %#v", want, directories)
+		}
+	}
+	for _, proxyPath := range []string{
+		`C:\work\build\compiledb-make-proxy-123\make.exe`,
+		`C:\compiledb-make-proxy-123\make.exe`,
+	} {
+		commandPath, err := makeProxyCommandPath(proxyPath)
+		if err != nil || strings.Contains(commandPath, `\`) || !shellSafeMakeProxyPath(commandPath) {
+			t.Fatalf("shell-safe fallback depends on short names: path=%q error=%v", commandPath, err)
+		}
+	}
+}
+
+func TestMakeProxyCreatesShellSafeFallback(t *testing.T) {
+	workingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory failed: %v", err)
+	}
+	proxyPath, cleanup, err := createDiscoveryMakeProxy(`/tools/gmake`, workingDir)
+	if err != nil {
+		t.Fatalf("create shell-safe Make proxy failed: %v", err)
+	}
+	defer cleanup()
+	if !shellSafeMakeProxyPath(proxyPath) {
+		t.Fatalf("created Make proxy is not shell-safe: %q", proxyPath)
+	}
+}

--- a/internal/make_wrap.go
+++ b/internal/make_wrap.go
@@ -363,6 +363,13 @@ func (t *Tool) MakeWrap(args []string) {
 
 	dryRunCmd := t.makeCommand(dryRunArgs...)
 	dryRunCmd.WaitDelay = makePipeWaitDelay
+	cleanupProxy, proxyErr := configureDiscoveryMakeProxy(dryRunCmd)
+	if proxyErr != nil {
+		t.StatusCode = 1
+		t.Logger.Errorf("configure recursive Make discovery failed: %v", proxyErr)
+		return
+	}
+	defer cleanupProxy()
 	dryRunCmd.Env = discoveryMakeEnvironment(dryRunCmd.Environ())
 	if usesStdin {
 		dryRunCmd.Stdin = bytes.NewReader(stdinData)

--- a/internal/make_wrap_test.go
+++ b/internal/make_wrap_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -762,8 +763,479 @@ func TestMakeWrapPreservesDirectoryOperandStartingWithModeFlag(t *testing.T) {
 	})
 	tool.MakeWrap([]string{"-C", "-qdir"})
 	commands := readCompilerTestCommands(t, outputFile)
-	if tool.StatusCode != 0 || len(commands) != 1 || commands[0].File != "operand.c" {
+	physicalBuildDir, err := filepath.EvalSymlinks(buildDir)
+	if err != nil {
+		t.Fatalf("resolve build directory failed: %v", err)
+	}
+	if tool.StatusCode != 0 || len(commands) != 1 || commands[0].File != "operand.c" ||
+		commands[0].Directory != trackedPathToSlash(physicalBuildDir) {
 		t.Fatalf("-C operand was changed: status=%d commands=%#v", tool.StatusCode, commands)
+	}
+}
+
+func TestMakeWrapTracksRecursiveMakeDirectory(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	projectDir := t.TempDir()
+	childDir := filepath.Join(projectDir, "child")
+	if err := os.Mkdir(childDir, 0o755); err != nil {
+		t.Fatalf("create child directory failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte("all:\n\t$(MAKE) -C child\n"), 0o644); err != nil {
+		t.Fatalf("write parent Makefile failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "Makefile"), []byte("all:\n\tcc -c child.c\n"), 0o644); err != nil {
+		t.Fatalf("write child Makefile failed: %v", err)
+	}
+	oldMakePath := makePath
+	makePath = makeExecutable
+	defer func() { makePath = oldMakePath }()
+
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{
+		BuildDir:     projectDir,
+		OutputFile:   outputFile,
+		RegexCompile: RegexCompile,
+		RegexFile:    RegexFile,
+		NoBuild:      true,
+		NoStrict:     true,
+	})
+	tool.MakeWrap(nil)
+
+	commands := readCompilerTestCommands(t, outputFile)
+	physicalChildDir, err := filepath.EvalSymlinks(childDir)
+	if err != nil {
+		t.Fatalf("resolve child directory failed: %v", err)
+	}
+	if tool.StatusCode != 0 || len(commands) != 1 || commands[0].File != "child.c" ||
+		commands[0].Directory != trackedPathToSlash(physicalChildDir) {
+		t.Fatalf("recursive Make directory was not tracked: status=%d commands=%#v", tool.StatusCode, commands)
+	}
+}
+
+func TestMakeWrapForcesDirectoryMarkersForRecursiveMake(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	proxyTempDir := filepath.Join(t.TempDir(), "proxy path '$#")
+	if err := os.Mkdir(proxyTempDir, 0o755); err != nil {
+		t.Fatalf("create proxy temporary directory failed: %v", err)
+	}
+	t.Setenv("TMPDIR", proxyTempDir)
+	projectDir := t.TempDir()
+	for _, directory := range []string{"raylib", "raylib/nested", "tests"} {
+		if err := os.MkdirAll(filepath.Join(projectDir, directory), 0o755); err != nil {
+			t.Fatalf("create %s directory failed: %v", directory, err)
+		}
+	}
+	parentMakefile := `all:
+	"$(MAKE)" --no-print-directory -C raylib
+	"$(MAKE)" --no-print-directory -C . root
+	"$(MAKE)" --no-print-directory -C tests
+
+root:
+	cc -c root.c
+`
+	raylibMakefile := `all:
+	cc -c raylib.c
+	"$(MAKE)" --no-print-directory -C nested
+`
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte(parentMakefile), 0o644); err != nil {
+		t.Fatalf("write parent Makefile failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "raylib", "Makefile"), []byte(raylibMakefile), 0o644); err != nil {
+		t.Fatalf("write raylib Makefile failed: %v", err)
+	}
+	for directory, source := range map[string]string{
+		"raylib/nested": "nested.c",
+		"tests":         "tests.c",
+	} {
+		contents := "all:\n\tcc -c " + source + "\n"
+		if err := os.WriteFile(filepath.Join(projectDir, directory, "Makefile"), []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s Makefile failed: %v", directory, err)
+		}
+	}
+
+	oldMakePath := makePath
+	makePath = makeExecutable
+	defer func() { makePath = oldMakePath }()
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{
+		BuildDir:     projectDir,
+		OutputFile:   outputFile,
+		RegexCompile: RegexCompile,
+		RegexFile:    RegexFile,
+		NoBuild:      true,
+		NoStrict:     true,
+	})
+	tool.MakeWrap(nil)
+
+	commands := readCompilerTestCommands(t, outputFile)
+	wantDirectories := map[string]string{
+		"raylib.c": filepath.Join(projectDir, "raylib"),
+		"nested.c": filepath.Join(projectDir, "raylib", "nested"),
+		"root.c":   projectDir,
+		"tests.c":  filepath.Join(projectDir, "tests"),
+	}
+	if tool.StatusCode != 0 || len(commands) != len(wantDirectories) {
+		t.Fatalf("recursive Make discovery failed: status=%d commands=%#v", tool.StatusCode, commands)
+	}
+	for _, command := range commands {
+		want, ok := wantDirectories[command.File]
+		if !ok {
+			t.Fatalf("unexpected recursive command: %#v", command)
+		}
+		physical, err := filepath.EvalSymlinks(want)
+		if err != nil {
+			t.Fatalf("resolve %s directory failed: %v", command.File, err)
+		}
+		if command.Directory != trackedPathToSlash(physical) {
+			t.Fatalf("unexpected %s directory: want %q, got %q", command.File, physical, command.Directory)
+		}
+	}
+}
+
+func TestRecursiveMakeArgumentsForceDirectoryMarkers(t *testing.T) {
+	for name, test := range map[string]struct {
+		arguments []string
+		want      []string
+	}{
+		"remove full option": {
+			arguments: []string{"--no-print-directory", "-C", "child", "all"},
+			want:      []string{"--print-directory", "-C", "child", "all"},
+		},
+		"remove abbreviation": {
+			arguments: []string{"--no-print-dir", "all"},
+			want:      []string{"--print-directory", "all"},
+		},
+		"preserve assignment": {
+			arguments: []string{"VALUE=--no-print-directory", "all"},
+			want:      []string{"--print-directory", "VALUE=--no-print-directory", "all"},
+		},
+		"preserve invalid attached value": {
+			arguments: []string{"--no-print-directory=value", "all"},
+			want:      []string{"--print-directory", "--no-print-directory=value", "all"},
+		},
+		"preserve option operand": {
+			arguments: []string{"-f", "--no-print-directory", "all"},
+			want:      []string{"--print-directory", "-f", "--no-print-directory", "all"},
+		},
+		"preserve goal after terminator": {
+			arguments: []string{"--", "--no-print-directory"},
+			want:      []string{"--print-directory", "--", "--no-print-directory"},
+		},
+		"terminator used as operand": {
+			arguments: []string{"-f", "--", "all"},
+			want:      []string{"--print-directory", "-f", "--", "all"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := recursiveMakeArguments(test.arguments); !slices.Equal(got, test.want) {
+				t.Fatalf("unexpected recursive Make arguments: want %#v, got %#v", test.want, got)
+			}
+		})
+	}
+}
+
+func TestConfigureDiscoveryMakeProxy(t *testing.T) {
+	command := exec.Command("/tools/gmake", "all")
+	originalPath := command.Path
+	originalEnvironment := append([]string(nil), command.Env...)
+	cleanup, err := configureDiscoveryMakeProxy(command)
+	if err != nil {
+		t.Fatalf("configure Make proxy failed: %v", err)
+	}
+	proxyPath := command.Args[0]
+	if command.Path != originalPath {
+		t.Fatalf("proxy changed the selected Make executable: %q", command.Path)
+	}
+	if !shellSafeMakeProxyPath(proxyPath) || executableBase(proxyPath) != "make" ||
+		!strings.HasPrefix(filepath.Base(filepath.Dir(proxyPath)), makeProxyDirectoryPrefix) {
+		t.Fatalf("unexpected recursive Make proxy: %q", proxyPath)
+	}
+	proxyExecutable := proxyPath
+	metadata, err := os.ReadFile(filepath.Join(filepath.Dir(proxyExecutable), makeProxyMetadataName))
+	if err != nil || string(metadata) != originalPath {
+		t.Fatalf("unexpected recursive Make metadata: contents=%q err=%v", metadata, err)
+	}
+	if !slices.Equal(command.Env, originalEnvironment) {
+		t.Fatalf("proxy changed the Make environment: %#v", command.Env)
+	}
+	cleanup()
+	if _, err := os.Stat(filepath.Dir(proxyExecutable)); !os.IsNotExist(err) {
+		t.Fatalf("proxy directory was not removed: %v", err)
+	}
+}
+
+func TestCreateDiscoveryMakeProxyUsesAbsolutePath(t *testing.T) {
+	processDir := t.TempDir()
+	oldWorkingDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory failed: %v", err)
+	}
+	if err := os.Chdir(processDir); err != nil {
+		t.Fatalf("change working directory failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWorkingDir) })
+	if err := os.Mkdir("relative-tmp", 0o755); err != nil {
+		t.Fatalf("create relative temporary directory failed: %v", err)
+	}
+	t.Setenv("TMPDIR", "relative-tmp")
+
+	proxyPath, cleanup, err := createDiscoveryMakeProxy("/tools/gmake")
+	if runtime.GOOS == "windows" {
+		if err == nil {
+			cleanup()
+			t.Fatalf("relative temporary directory was accepted on Windows: %q", proxyPath)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("create Make proxy failed: %v", err)
+	}
+	defer cleanup()
+	if !filepath.IsAbs(proxyPath) {
+		t.Fatalf("Make proxy path is relative: %q", proxyPath)
+	}
+	if filepath.Clean(filepath.Dir(filepath.Dir(proxyPath))) != "/tmp" {
+		t.Fatalf("relative temporary directory did not fall back to /tmp: %q", proxyPath)
+	}
+}
+
+func TestMakeWrapProxyPreservesDefaultMakeOrigin(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	projectDir := t.TempDir()
+	makefile := `ifeq ($(origin MAKE),default)
+SOURCE = default.c
+else
+SOURCE = changed.c
+endif
+all:
+	cc -c $(SOURCE)
+`
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte(makefile), 0o644); err != nil {
+		t.Fatalf("write Makefile failed: %v", err)
+	}
+	oldMakePath := makePath
+	makePath = makeExecutable
+	defer func() { makePath = oldMakePath }()
+
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{
+		BuildDir:     projectDir,
+		OutputFile:   outputFile,
+		RegexCompile: RegexCompile,
+		RegexFile:    RegexFile,
+		NoBuild:      true,
+		NoStrict:     true,
+	})
+	tool.MakeWrap(nil)
+	commands := readCompilerTestCommands(t, outputFile)
+	if tool.StatusCode != 0 || len(commands) != 1 || commands[0].File != "default.c" {
+		t.Fatalf("proxy changed the default MAKE variable: status=%d commands=%#v", tool.StatusCode, commands)
+	}
+}
+
+func TestMakeWrapProxyDoesNotLeakEnvironment(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	const proxyEnvironment = "COMPILEDB_INTERNAL_MAKE_PROXY"
+	oldValue, existed := os.LookupEnv(proxyEnvironment)
+	if err := os.Unsetenv(proxyEnvironment); err != nil {
+		t.Fatalf("unset proxy environment failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if existed {
+			_ = os.Setenv(proxyEnvironment, oldValue)
+		} else {
+			_ = os.Unsetenv(proxyEnvironment)
+		}
+	})
+
+	projectDir := t.TempDir()
+	childDir := filepath.Join(projectDir, "child")
+	if err := os.Mkdir(childDir, 0o755); err != nil {
+		t.Fatalf("create child directory failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte("all:\n\t$(MAKE) --no-print-directory -C child\n"), 0o644); err != nil {
+		t.Fatalf("write parent Makefile failed: %v", err)
+	}
+	childMakefile := `ifdef COMPILEDB_INTERNAL_MAKE_PROXY
+SOURCE = leaked.c
+else
+SOURCE = clean.c
+endif
+all:
+	cc -c $(SOURCE)
+`
+	if err := os.WriteFile(filepath.Join(childDir, "Makefile"), []byte(childMakefile), 0o644); err != nil {
+		t.Fatalf("write child Makefile failed: %v", err)
+	}
+	oldMakePath := makePath
+	makePath = makeExecutable
+	defer func() { makePath = oldMakePath }()
+
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{
+		BuildDir:     projectDir,
+		OutputFile:   outputFile,
+		RegexCompile: RegexCompile,
+		RegexFile:    RegexFile,
+		NoBuild:      true,
+		NoStrict:     true,
+	})
+	tool.MakeWrap(nil)
+	commands := readCompilerTestCommands(t, outputFile)
+	if tool.StatusCode != 0 || len(commands) != 1 || commands[0].File != "clean.c" {
+		t.Fatalf("proxy environment leaked into recursive Make: status=%d commands=%#v", tool.StatusCode, commands)
+	}
+}
+
+func TestMakeWrapProxyPreservesRecursiveEnvironmentOverrides(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	projectDir := t.TempDir()
+	childDir := filepath.Join(projectDir, "child")
+	grandchildDir := filepath.Join(projectDir, "grandchild")
+	for _, directory := range []string{childDir, grandchildDir} {
+		if err := os.Mkdir(directory, 0o755); err != nil {
+			t.Fatalf("create directory failed: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte("all:\n\t$(MAKE) -e --no-print-directory -C child\n"), 0o644); err != nil {
+		t.Fatalf("write parent Makefile failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "Makefile"), []byte("MAKE = /bin/false\nall:\n\t$(MAKE) -C ../grandchild\n"), 0o644); err != nil {
+		t.Fatalf("write child Makefile failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(grandchildDir, "Makefile"), []byte("all:\n\tcc -c should-not-run.c\n"), 0o644); err != nil {
+		t.Fatalf("write grandchild Makefile failed: %v", err)
+	}
+	oldMakePath := makePath
+	makePath = makeExecutable
+	defer func() { makePath = oldMakePath }()
+
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{BuildDir: projectDir, OutputFile: outputFile, NoBuild: true, NoStrict: true})
+	tool.MakeWrap(nil)
+	if tool.StatusCode == 0 {
+		t.Fatal("recursive -e no longer honored the child Makefile's MAKE value")
+	}
+	if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
+		t.Fatalf("failed discovery updated the database: %v", err)
+	}
+}
+
+func TestMakeWrapProxyPreservesExplicitMakeAssignment(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte("all:\n\t$(MAKE) recursive\n\nrecursive:\n\tcc -c should-not-run.c\n"), 0o644); err != nil {
+		t.Fatalf("write Makefile failed: %v", err)
+	}
+	oldMakePath := makePath
+	makePath = makeExecutable
+	defer func() { makePath = oldMakePath }()
+
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{BuildDir: projectDir, OutputFile: outputFile, NoBuild: true, NoStrict: true})
+	tool.MakeWrap([]string{"MAKE:=/bin/false"})
+	if tool.StatusCode == 0 {
+		t.Fatal("proxy overrode an explicit MAKE assignment")
+	}
+	if _, err := os.Stat(outputFile); !os.IsNotExist(err) {
+		t.Fatalf("failed discovery updated the database: %v", err)
+	}
+}
+
+func TestMakeWrapProxyUsesSelectedMakeExecutableRecursively(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	projectDir := t.TempDir()
+	childDir := filepath.Join(projectDir, "child")
+	if err := os.Mkdir(childDir, 0o755); err != nil {
+		t.Fatalf("create child directory failed: %v", err)
+	}
+	makeAlias := filepath.Join(projectDir, "g make'$")
+	if err := os.Symlink(makeExecutable, makeAlias); err != nil {
+		t.Skipf("create Make alias failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte("all:\n\t$(MAKE) --no-print-directory -C child\n"), 0o644); err != nil {
+		t.Fatalf("write parent Makefile failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(childDir, "Makefile"), []byte("all:\n\tcc -c custom.c\n"), 0o644); err != nil {
+		t.Fatalf("write child Makefile failed: %v", err)
+	}
+
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{
+		BuildDir:     projectDir,
+		OutputFile:   outputFile,
+		RegexCompile: RegexCompile,
+		RegexFile:    RegexFile,
+		MakeCommand:  makeAlias,
+		NoBuild:      true,
+		NoStrict:     true,
+	})
+	tool.MakeWrap(nil)
+	commands := readCompilerTestCommands(t, outputFile)
+	physicalChildDir, err := filepath.EvalSymlinks(childDir)
+	if err != nil {
+		t.Fatalf("resolve child directory failed: %v", err)
+	}
+	if tool.StatusCode != 0 || len(commands) != 1 || commands[0].File != "custom.c" ||
+		commands[0].Directory != trackedPathToSlash(physicalChildDir) {
+		t.Fatalf("selected Make was not proxied recursively: status=%d commands=%#v", tool.StatusCode, commands)
+	}
+}
+
+func TestMakeWrapRemovesProxyAfterDiscoveryFailure(t *testing.T) {
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		t.Skip("GNU Make is not available")
+	}
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	projectDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectDir, "Makefile"), []byte("all:\n\t$(MAKE) --no-print-directory missing-target\n"), 0o644); err != nil {
+		t.Fatalf("write Makefile failed: %v", err)
+	}
+	oldMakePath := makePath
+	makePath = makeExecutable
+	defer func() { makePath = oldMakePath }()
+
+	tool := newTestTool(t, Config{
+		BuildDir:   projectDir,
+		OutputFile: filepath.Join(t.TempDir(), "compile_commands.json"),
+		NoBuild:    true,
+		NoStrict:   true,
+	})
+	tool.MakeWrap(nil)
+	if tool.StatusCode == 0 {
+		t.Fatal("recursive Make failure was not propagated")
+	}
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatalf("read temporary directory failed: %v", err)
+	}
+	for _, entry := range entries {
+		if strings.HasPrefix(entry.Name(), makeProxyDirectoryPrefix) {
+			t.Fatalf("proxy directory was not removed: %q", entry.Name())
+		}
 	}
 }
 

--- a/internal/parser_test.go
+++ b/internal/parser_test.go
@@ -2407,6 +2407,7 @@ func TestMakeCommandDirectory(t *testing.T) {
 		"attached":          {line: "gmake -Csub", base: "/project", want: "/project/sub"},
 		"long":              {line: "mingw32-make --directory=sub", base: "/project", want: "/project/sub"},
 		"multiple":          {line: "make -C one --directory two", base: "/project", want: "/project/one/two"},
+		"current directory": {line: "make -C .", base: "/project", want: "/project"},
 		"UNC":               {line: "make -C sub", base: "//server/share/project", want: "//server/share/project/sub"},
 		"absolute resets":   {line: "make -C one -C /other", base: "/project", want: "/other"},
 		"option terminator": {line: "make -C one -- -C two", base: "/project", want: "/project/one"},
@@ -2445,6 +2446,26 @@ func TestMakeCommandDirectory(t *testing.T) {
 				t.Fatalf("unexpected make directory: want %q, got %q, ok=%v", test.want, got, ok)
 			}
 		})
+	}
+}
+
+func TestParseKeepsCurrentDirectoryForMakeDot(t *testing.T) {
+	projectDir := t.TempDir()
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{
+		InputFile:    "stdin",
+		OutputFile:   outputFile,
+		BuildDir:     projectDir,
+		RegexCompile: RegexCompile,
+		RegexFile:    RegexFile,
+		NoStrict:     true,
+	})
+
+	tool.Parse([]string{"make -C .", "gcc -c current.c"})
+	commands := readCompilerTestCommands(t, outputFile)
+	if len(commands) != 1 || commands[0].File != "current.c" ||
+		commands[0].Directory != trackedPathToSlash(projectDir) {
+		t.Fatalf("make -C . changed the tracked directory: %#v", commands)
 	}
 }
 
@@ -2873,6 +2894,44 @@ func TestParseConfirmsMakeCommandDirectoryFrame(t *testing.T) {
 	if len(commands) != 2 || commands[0].Directory != trackedPathToSlash(childDir) ||
 		commands[1].Directory != trackedPathToSlash(projectDir) {
 		t.Fatalf("make directory frame was duplicated: %#v", commands)
+	}
+}
+
+func TestParseTracksNestedMakeDirectoryMarkers(t *testing.T) {
+	projectDir := t.TempDir()
+	childDir := filepath.Join(projectDir, "child")
+	grandchildDir := filepath.Join(childDir, "grandchild")
+	outputFile := filepath.Join(t.TempDir(), "compile_commands.json")
+	tool := newTestTool(t, Config{
+		InputFile:    "stdin",
+		OutputFile:   outputFile,
+		BuildDir:     projectDir,
+		RegexCompile: RegexCompile,
+		RegexFile:    RegexFile,
+		NoStrict:     true,
+	})
+
+	tool.Parse([]string{
+		"make[1]: Entering directory '" + childDir + "'",
+		"gcc -c child-before.c",
+		"make[2]: Entering directory '" + grandchildDir + "'",
+		"gcc -c grandchild.c",
+		"make[2]: Leaving directory '" + grandchildDir + "'",
+		"gcc -c child-after.c",
+		"make[1]: Leaving directory '" + childDir + "'",
+		"gcc -c parent.c",
+	})
+
+	commands := readCompilerTestCommands(t, outputFile)
+	wantFiles := []string{"child-before.c", "grandchild.c", "child-after.c", "parent.c"}
+	wantDirectories := []string{childDir, grandchildDir, childDir, projectDir}
+	if len(commands) != len(wantFiles) {
+		t.Fatalf("unexpected nested Make commands: %#v", commands)
+	}
+	for i := range commands {
+		if commands[i].File != wantFiles[i] || commands[i].Directory != trackedPathToSlash(wantDirectories[i]) {
+			t.Fatalf("nested Make directory %d was not tracked: %#v", i, commands)
+		}
 	}
 }
 


### PR DESCRIPTION
Use a discovery-only Make proxy to preserve directory markers across sibling and nested recursive builds without changing the real build. 
Add regressions for make -C . and nested directory stacks. #8  #9 
